### PR TITLE
Feature/issue 77/auto refresh data

### DIFF
--- a/src/components/authorPosts/AuthorPosts.container.tsx
+++ b/src/components/authorPosts/AuthorPosts.container.tsx
@@ -30,8 +30,13 @@ const AuthorPostsContainer: FC<UserSpaceDataType> = ({
     mountedRef.current = true
     updatePostList()
 
+    const timer = setInterval(() => {
+      updatePostList()
+    }, 60000)
+
     return () => {
       mountedRef.current = false
+      clearInterval(timer)
     }
   }, [updatePostList])
 

--- a/src/components/feed/Feed.container.tsx
+++ b/src/components/feed/Feed.container.tsx
@@ -9,7 +9,7 @@ const FeedContainer: FC = () => {
 
   const [feedList, setFeedList] = useState<PostCardListType>([])
 
-  const getinitialData = useCallback(async () => {
+  const updatePostList = useCallback(async () => {
     axios.get('/api/feed')
     .then(({ data }: GetDataType) => {
       if(!mountedRef.current) return
@@ -23,12 +23,18 @@ const FeedContainer: FC = () => {
 
   useEffect(() => {
     mountedRef.current = true
-    getinitialData()
+    updatePostList()
+
+    const timer = setInterval(() => {
+      updatePostList()
+    }, 60000)
+
     
     return () => {
       mountedRef.current = false
+      clearInterval(timer)
     }
-  }, [getinitialData])
+  }, [updatePostList])
 
   return (
     <Feed list={feedList} />

--- a/src/components/postDisplay/PostDisplay.container.tsx
+++ b/src/components/postDisplay/PostDisplay.container.tsx
@@ -20,7 +20,7 @@ const PostDisplayContainer: FC<PostDisplayType> = ({ ...args }) => {
   const [isDescriptionRevlealed, setIsDescriptionRevlealed] = useState(false)
   const post = useAppSelector(selectPost)
 
-  const initGsap = useCallback(() => {
+  const initGsap = () => {
     tlDescriptionRef.current.fromTo('#description-section', {
       height: 0
     }, {
@@ -28,7 +28,7 @@ const PostDisplayContainer: FC<PostDisplayType> = ({ ...args }) => {
       ease: 'power1.inOut',
       height: descriptioncContentRef.current?.clientHeight,
     }, 0)
-  }, [descriptioncContentRef.current])
+  }
 
   const revealDescription = useCallback(() => {
     setIsDescriptionRevlealed(true)


### PR DESCRIPTION
# Trello Task
**Primary task:** Auto refresh Post List data => issue `77`

# Context
On pages where the feed is present, the list data will be fetched every 60 seconds.
I have also removed un cached a function as it was causing issues and was popping up as an esLint issue.